### PR TITLE
Added ability to match host aliases against standby list in tegu_ha.

### DIFF
--- a/system/tegu_ha.py
+++ b/system/tegu_ha.py
@@ -153,7 +153,7 @@ def my_aliases():
         map[toks[0]] = True
     else:
         p1 = subprocess.Popen( ["dig", toks[1], "axfr"], stdout=subprocess.PIPE )
-        p2 = subprocess.Popen( ["sed", "-r", "/^" + toks[0] + "[^a-zA-Z]/! d; s/. .*//"],
+        p2 = subprocess.Popen( ["sed", "-r", "/^" + toks[0] + "[^a-zA-Z0-9]/! d; s/. .*//"],
             stdin=p1.stdout, stdout=subprocess.PIPE )
         for a in str.split( p2.communicate()[0], "\n" ):
             if not a == None:

--- a/system/tegu_ha.py
+++ b/system/tegu_ha.py
@@ -18,21 +18,25 @@
 # ---------------------------------------------------------------------------
 #
 
-'''	Mnemonic:	tegu_ha.py
-	Abstract:	High availability script for tegu. Pings other tegu's in the
-                standby_list. If no other tegu is running, then makes the
-                current tegu active. If it finds multiple tegu running, then
-                determines whether current tegu should be shut down or not based
-                on db timestamps. Assumes that db checkpoints from other tegus
-                do not override our checkpoints
+'''	
+        Mnemonic:   tegu_ha.py
+        Abstract:   High availability script for tegu. Pings other tegu's in the
+                    standby_list. If no other tegu is running, then makes the
+                    current tegu active. If it finds multiple tegu running, then
+                    determines whether current tegu should be shut down or not based
+                    on db timestamps. Assumes that db checkpoints from other tegus
+                    do not override our checkpoints
 
-  	Date:		15 December 2015
-	Author:		Kaustubh Joshi
-	Mod:		2014 15 Dec - Created script
-				2015 30 Jan - Minor fixes.
-                2015 04 Feb - Change to ensure that the stanby file is always
-                    there when tegu isn't running on the current host. (needed
-                    only for monitoring at this point).
+        Date:       15 December 2015
+        Author:     Kaustubh Joshi
+        Mod:        2014 15 Dec - Created script
+                    2015 30 Jan - Minor fixes.
+                    2015 04 Feb - Change to ensure that the stanby file is always
+                        there when tegu isn't running on the current host. (needed
+                        only for monitoring at this point).
+                    2015 06 Aug - Adjusted retry to offset response time delays.
+                    2015 11 Aug - Added ability to recognise all host aliases for
+                        this machine.
  ------------------------------------------------------------------------------
 
   Algorithm
@@ -77,7 +81,7 @@ RETRY_COUNT = 3      # How many times to retry ping command
 CONNECT_TIMEOUT = 3  # Ping timeout
 
 DEACTIVATE_CMD = '/usr/bin/tegu_standby on;' \
-    'killall tegu; killall tegu_agent'               # Command to kill tegu
+    'killall tegu >/dev/null 2>&1; killall tegu_agent >/dev/null 2>&1'  # Command to kill tegu
 ACTIVATE_CMD = '/usr/bin/tegu_standby off;' \
     '/usr/bin/start_tegu; /usr/bin/start_tegu_agent' # Command to start tegu
 
@@ -87,7 +91,7 @@ SYNC_CMD = '/usr/bin/tegu_synch'
 # HA Configuration
 HEARTBEAT_SEC = 5                    # Heartbeat interval in seconds
 PRI_WAIT_SEC = 5                     # Backoff to let higher prio tegu take over
-STDBY_LIST = ETCDIR + '/standby_list'# list of other hosts that might run tegu
+STDBY_LIST = ETCDIR + '/standby_list' # list of other hosts that might run tegu
 
 # if present then this is a standby machine and we don't start
 STDBY_FILE = ETCDIR + '/standby'
@@ -129,6 +133,34 @@ def get_checkpoint(host=''):
     except subprocess.CalledProcessError:
         warn("Could not sync chkpts from %s" % host)
     return False
+
+def my_aliases():
+    '''
+        returns a map (dictionary?) of alias names. if map[name] == true then
+        name is an alias for this host.
+
+        this works if hostname returns foo and aliases are some 'extension'
+        of foo (e.g. foo-ops), but if foo-ops is returned by host name
+        we won't find foo.
+    '''
+
+    p = subprocess.Popen( ["hostname", "-f"], stdout=subprocess.PIPE, shell=False )
+    sout = p.communicate()[0]
+    toks = str.split( str.split( sout, "\n" )[0], ".", 1 ) # split host and domain
+
+    map = {}
+    if len( toks ) == 1:    # odd case where -f returns just foo and not foo.domain
+        map[toks[0]] = True
+    else:
+        p1 = subprocess.Popen( ["dig", toks[1], "axfr"], stdout=subprocess.PIPE )
+        p2 = subprocess.Popen( ["sed", "-r", "/^" + toks[0] + "[^a-zA-Z]/! d; s/. .*//"],
+            stdin=p1.stdout, stdout=subprocess.PIPE )
+        for a in str.split( p2.communicate()[0], "\n" ):
+            if not a == None:
+                map[a] = True
+
+    return map
+
 
 def extract_dt(dt_str, dt_col, tm_col):
     '''
@@ -307,31 +339,35 @@ def main():
 
     logit("tegu_ha v1.0 started")
 
-    this_node = socket.getfqdn()
 
     ok = False
     mcount = 0                  # critical error after an hour of waiting
     while not ok:               # loop until we find us
-        ok = True
-        # Ready list of standby tegu nodes and find us
+        alias_map = my_aliases()    # generate each time round in case dns changes
+
+        ok = False
+        # Read list of standby tegu nodes and find us
         standby_list = [l.strip() for l in open(STDBY_LIST, 'r')]
 
-        try:
-            priority = standby_list.index(this_node)
-            standby_list.remove(this_node)
-        except ValueError:
+        for i in range( len( standby_list ) ):
+            if alias_map.has_key( standby_list[i] ):
+                priority = i
+                ok = True
+                this_node = standby_list[i]
+                break
+
+        if not ok:
             if mcount == 0:         # dont flood the log
-                logit("Could not find host "+this_node+" in standby list: %s (waiting)" % STDBY_LIST)
+                logit("Could not find this host in standby list: %s (waiting)" % STDBY_LIST)
+                logit( "aliases for this host: %s" % alias_map )
             else:
                 if mcount == 60:
-                    crit("Could not find host "+this_node+" in standby list: %s" % STDBY_LIST)
+                    crit("Could not find this host in standby list: %s" % STDBY_LIST)
                     mcount = 0      # another message in about an hour
             mcount += 1
-            ok = False
             time.sleep( 60 )
 
-    if mcount > 0:
-        logit( "finally found host "+this_node+" in standby list: %s" % STDBY_LIST)
+    logit( "host matched in standby list: %s priority=%d" % (standby_list[priority], priority) )
 
     # Loop forever listening to heartbeats
     main_loop(standby_list, this_node, priority)


### PR DESCRIPTION
This change will allow the standby list to contain the foo-ops.domain names as we want. The ha process will now get a list of alias names for the host from DNS, and compare those to the names listed in the standby list. 
