### PR TITLE
tegu_req to extract url from keystone; bug fix in tegu

### DIFF
--- a/doc/tegu_req.1
+++ b/doc/tegu_req.1
@@ -26,6 +26,7 @@
 .\"     Mods:		14 Jun 2015 - Created
 .\"					01 Sep 2015 - Filled in unfinished section.
 .\"					18 Sep 2015 - Allow mirrored ports to be ID-ed by neutron UUID
+.\"					22 Sep 2015 - Updates based on code changes.
 .\"
 .TH TEGU_REQ 1 "Tegu Manual"
 .CM 4
@@ -48,6 +49,12 @@ For details on the Tegu HTTP API, look at \fItegu(8)\fP.
 .SH COMMAND LINE OPTIONS
 \fItegu_req\fR interprets the following options:
 .\" ==========
+.TP 8
+.B \-c
+Causes a search of the keystone service catalogue to be skipped. If not supplied, then 
+tegu_req will attempt to find the URL for Tegu by searching for the netqos service 
+name (see -S) in the catalogue.  If the service is not defined, then localhost is 
+assumed unless -h is supplied.
 .TP 8
 .B \-d
 Causes JSON output from Tegu to be formatted in a dotted hierarchical style.
@@ -78,9 +85,16 @@ Only useful if -T is not used.
 Causes extra arguments, in the form of key=value, to be passed to Tegu for certain requests.
 The commands where this is used are: listres, listhosts, graph, reserve, steer.
 .TP 8
+.B \-R name
+Supplies the region name overriding the OS_REGION from the environment.
+.TP 8
 .B \-r name
 Allow specification of a "root" name for the JSON output.
 The default root name is the name of the command (e.g. "graph" when using the graph command).
+.TP 8
+.B \-S name
+Allows the user to supply the service name that is searched for in the keystone catalogue.
+If not supplied netqos is used.
 .TP 8
 .B \-s
 Causes tegu_req to use secure TLS (HTTPS) protocol for requests to Tegu.

--- a/doc/tegu_req.1
+++ b/doc/tegu_req.1
@@ -188,9 +188,13 @@ reservation to be deleted if a matching cookie is supplied.
 The cookie may not contain any spaces, and does not need to be unique across reservations.
 .IP
 \fBdscp\fP
-The DSCP value to use.
-Must be between 0 and 64.
-The default, if not specified is WTF?
+The traffic classification. 
+This is one of three strings, "voice", "control", or "data"; each may be prefixed with 
+"global_."
+The strings map to one of the supported ITONS DSCP values.
+If the global_ prefix is added, the traffic markings (dscp values) are kept as the traffic 
+passes out of the cloud environment. 
+If omitted, "voice" is assumed.
 
 .TP 8
 .B owreserve [bandwidth_in,]bandwidth_out [start-]expiry host1-host2 cookie [dscp]

--- a/gizmos/switch.go
+++ b/gizmos/switch.go
@@ -159,8 +159,8 @@ func (s *Switch) Has_host( host *string ) (bool) {
 		return false
 	}
 
-	if s.vmid[*host] != nil {			// allow searches based on the uuid
-		return s.vmid[*host]
+	if s.hvmid[*host] != nil {			// allow searches based on the uuid
+		return true
 	}
 
 	return s.hosts[*host]

--- a/gizmos/switch.go
+++ b/gizmos/switch.go
@@ -42,6 +42,7 @@
 					comments and switch to stringer interface instead of To_str(). Added support for
 					oneway bandwidth reserations with a function that checks outbound capacity
 					on all switch links.
+				10 Sep 2015 - Allow finding attached 'hosts' based on uuid.
 */
 
 package gizmos
@@ -151,14 +152,18 @@ func (s *Switch) Add_host( host *string, vmid *string, port int ) {
 
 /*
 	Returns true if the named host is attached to the switch.
+	The host may be a pointer to either a host name or uuid string.
 */
 func (s *Switch) Has_host( host *string ) (bool) {
 	if s == nil {
 		return false
 	}
 
-	r := s.hosts[*host]
-	return r
+	if s.vmid[*host] != nil {			// allow searches based on the uuid
+		return s.vmid[*host]
+	}
+
+	return s.hosts[*host]
 }
 
 /*

--- a/main/tegu.go
+++ b/main/tegu.go
@@ -133,6 +133,7 @@
 				06 Jul 2015 : Version bump
 				29 Jul 2015 : Tracker bug fixes (263,266) version bump.
 				03 Sep 2015 : Correct panic in network.go.
+				08 Sep 2015 : Prevent checkpoint files with same timestamp (gh#22).
 
 	Version number "logic":
 				3.0		- QoS-Lite version of Tegu
@@ -167,7 +168,7 @@ func usage( version string ) {
 
 func main() {
 	var (
-		version		string = "v3.1.4/19035"		// 3.1.x == steering branch version (.2 steering only, .3 steering+mirror+lite)
+		version		string = "v3.1.4/19085"		// 3.1.x == steering branch version (.2 steering only, .3 steering+mirror+lite)
 		cfg_file	*string  = nil
 		api_port	*string						// command line option vars must be pointers
 		verbose 	*bool

--- a/managers/fq_req.go
+++ b/managers/fq_req.go
@@ -27,6 +27,7 @@
 	Mods:		24 Sep 2014 : Added support for vlan id setting.
 				16 Jan 2015 : Support port masks in flow-mods.
 				20 Apr 2015 : Correct bug - not passing direction of external IP address to agent.
+				01 Sep 2015 : Changed bleat level for bwow debugging message.
 */
 
 package managers
@@ -238,9 +239,9 @@ func ( fq *Fq_req ) To_bwow_map( ) ( fmap map[string]string ) {
 		}
 	}
 
-	if fq_sheep.Would_baa( 1 ) {
+	if fq_sheep.Would_baa( 2 ) {
 		for k, v := range fmap {
-			fq_sheep.Baa( 3, "fq_req to action id=%s %s = %s", fq.Id, k, v )
+			fq_sheep.Baa( 2, "fq_req to action id=%s %s = %s", fq.Id, k, v )
 		}
 	}
 

--- a/managers/network.go
+++ b/managers/network.go
@@ -626,12 +626,14 @@ func build( old_net *Network, flhost *string, max_capacity int64, link_headroom 
 		hr_factor = 100 - int64( link_headroom )
 	}
 
+
+	// REVAMP:   eliminate the floodlight call openstack interface should be sending us a list of endpoints to use; use them directly
 	if strings.Index( *flhost, ":" ) >= 0  {
 		links = gizmos.FL_links( flhost )					// request the current set of links from floodlight
 		hlist = gizmos.FL_hosts( flhost )					// get a current host list from floodlight
 	} else {
 		hlist = old_net.build_hlist()						// simulate output from floodlight by building the host list from openstack maps
-		links, err = gizmos.Read_json_links( *flhost )
+		links, err = gizmos.Read_json_links( *flhost )		// build links from the topo file; if empty/missing, we'll generate a dummy next
 		if err != nil || len( links ) <= 0 {
 			if host_list != nil {
 				net_sheep.Baa_some( "star", 500, 1, "generating a dummy star topology: json file empty, or non-existent: %s", *flhost )
@@ -660,7 +662,7 @@ func build( old_net *Network, flhost *string, max_capacity int64, link_headroom 
 		return
 	}
 
-	for i := range links {								// parse all links returned from the controller
+	for i := range links {								// parse all links returned from the controller (build our graph of switches and links)
 		if links[i].Capacity <= 0 {
 			links[i].Capacity = max_capacity			// default if it didn't come from the source
 		}
@@ -713,12 +715,13 @@ func build( old_net *Network, flhost *string, max_capacity int64, link_headroom 
 		n.hupdate = false
 	}
 
-	for i := range hlist {			// parse the unpacked json; structs are very dependent on the floodlight output; TODO: change FL_host to return a generic map
+	// REVAMP:  expect hlist to be a list of endpoints which we just need to map to switches and add.
+	for i := range hlist {			// parse the unpacked json (host list); structs are very dependent on the floodlight output; TODO: change FL_host to return a generic map
 		if len( hlist[i].Mac )  > 0  && len( hlist[i].AttachmentPoint ) > 0 {		// switches come back in the list; if there are no attachment points we assume it's a switch & drop
 			ip6 = ""
 			ip4 = ""
 
-			if len( hlist[i].Ipv4 ) > 0 { 							// floodlight returns them all in a list; openstack produces them one at a time, so for now this does snarf everything
+			if len( hlist[i].Ipv4 ) > 0 { 							// floodlight returns them all in a list; openstack produces them one at a time, so for now this doesn't snarf everything
 				if strings.Index( hlist[i].Ipv4[0], ":" ) >= 0 {	// if emulating floodlight, we get both kinds of IP in this field, one per hlist entry (ostack yields unique mac for each ip)
 					ip6 = hlist[i].Ipv4[0];
 				} else {
@@ -1165,9 +1168,10 @@ func Network_mgr( nch chan *ipc.Chmsg, sdn_host *string ) {
 						p, ok := req.Req_data.( *gizmos.Pledge_bwow )
 						if ok {
 							src, dest := p.Get_hosts( )									// we assume project/host-name
-							net_sheep.Baa( 1,  "network: bwow reservation request received: %s -> %s", *src, *dest )
 
 							if src != nil && dest != nil {
+								net_sheep.Baa( 1,  "network: bwow reservation request received: %s -> %s", *src, *dest )
+
 								usr := "nobody"											// default dummy user if not project/host
 								toks := strings.SplitN( *src, "/", 2 )					// suss out project name
 								if len( toks ) > 1 {
@@ -1176,7 +1180,7 @@ func Network_mgr( nch chan *ipc.Chmsg, sdn_host *string ) {
 	
 								ips, err := act_net.name2ip( src )
 								if err == nil {
-									ipd, err = act_net.name2ip( dest )
+									ipd, _ = act_net.name2ip( dest )				// for an external dest, this can be nil which is not an error
 								}
 
 								sh := act_net.hosts[*ips]

--- a/managers/osif_proj.go
+++ b/managers/osif_proj.go
@@ -472,55 +472,6 @@ func (p *osif_project) Get_all_info( creds *ostack.Ostack, inc_project bool ) ( 
 	return
 }
 
-/*
-	Builds an array of gizmos.Endpt structs for all VMs known to the project.
-*/
-/*
-REVAMP:  finish
-func (p *osif_project) Build_eplist( creds *ostack.Ostack, inc_project bool ) ( eplist []*gizmos.Endpt, err error ) {
-
-	err = nil
-	ilist = nil
-
-	if p == nil  ||  creds == nil {
-		err = fmt.Errorf( "creds were nil" )
-		osif_sheep.Baa( 2, "lazy update: unable to get_all: nil creds" )
-		return
-	}
-
-	if time.Now().Unix() - p.lastfetch > 90 {					// if not fresh force a reload first
-		err = p.refresh_maps( creds )
-		osif_sheep.Baa( 2, "lazy update: data reload for: build_ep" )
-		if err != nil {
-			return
-		}
-	}
-
-	
-	found := 0
-	ilist = make( []*gizmos.Endpt, len( p.ip2uuid ) )
-//func Mk_endpt( uuid, string, phost string, project string, ip string, switch *Switch, port int ) (h *Endporint) {
-
-	for k, _ := range p.ip2uuid {				// translate each ip address to a unique uuid that is in the OVS interface's external id list
-		name := p.ip2vm[k]
-		_, id, ip4, fip4, mac, gw, phost, gwmap, _, lerr := p.Get_info( &k, creds, true )
-		if lerr == nil  {
-			if name == nil {
-				n := "unknown"
-				name = &n
-			}
-			ilist[found] = Mk_netreq_vm( name, id, ip4, nil, phost, mac, gw, fip4, gwmap )
-			found++
-		}
-	}
-
-	pname, _ := creds.Get_project()
-	osif_sheep.Baa( 1, "get all osvm info found %d VMs in %s", found, *pname )
-
-	return
-}
-*/
-
 /* Public interface to get the default gateway (router) for a project. Causes data to
 	be loaded if stale.  Search is the project name or ID and can be of the form
 	project/<stuff> where stuff will be ignored. New data (return) is true if the data


### PR DESCRIPTION
Changes to tegu_req to allow it to pull the URL from the keystone service catalogue by default. Updated related man page. 

Corrected bug in gizmos/switch.go so that uuid can be used to look for a host while searching for a bandwidth path. 

Some comment changes added to the code to mark sections that need to be revamped with regard to pending dynamic support changes. 
