### PR TITLE
Added passthru reservation support.

### DIFF
--- a/agent/bandwidth/ql_pass_fmods.ksh
+++ b/agent/bandwidth/ql_pass_fmods.ksh
@@ -1,0 +1,236 @@
+#!/usr/bin/env ksh
+# vi: sw=4 ts=4:
+#
+# ---------------------------------------------------------------------------
+#   Copyright (c) 2013-2015 AT&T Intellectual Property
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+# ---------------------------------------------------------------------------
+#
+
+#	Mnemonic:	ql_pass_fmods
+#	Abstract:	Generates all needed flow-mods on an OVS for a passthrough reseration.
+#				The passthrough reservation allows a VM to set its own DSCP markings which
+#				our priority 10 flow-mod doesn't reset to 0 as the traffic goes out. 
+#
+#				Flow mods are set up this way:
+#					inbound (none)
+#
+#					outbound
+#						p400 Match:
+#								meta == 0 &&
+#								reservation VM mac
+#								[potocol and port]
+#							 Action:
+#								mark with meta value (-M)
+#
+#							
+#	Date:		26 January 2016
+# 	Author: 	E. Scott Daniels
+#
+#	Mods:
+# ---------------------------------------------------------------------------------------------------------
+
+function logit
+{
+	echo "$(date "+%s %Y/%m/%d %H:%M:%S") $argv0: $@" >&2
+}
+
+function usage
+{
+	echo "$argv0 v1.0/11216"
+	echo "usage: $argv0 -s src-mac|endpoint [-n] [-S procol:[address:]port] [-t hard-timeout]"
+	echo "usage: $argv0 [-X] # delete all"
+	echo "For -S address can be ipv4 or ipv6; ipv6 must be in brackets. Port should be 0 for all ports"
+}
+
+# given a string that could be mac or endpoint, convert to mac and return the mac and the 
+# bridge that we found it on.  If a mac is passed in, we don't return a bridge as there 
+# could be duplicate mac addresses out there (different vlans) so we can't be sure which 
+# bridge the mac is on. 
+function ep2mac
+{
+	if [[ $1 == *":"* ]]
+	then
+		echo "$1" ""
+	fi
+
+	typeset sw=""
+	typeset mac=""
+	ovs_sp2uuid -a | awk -v target="$1" '
+		/^switch:/ {
+			sw = $NF;
+			next;
+		}
+		/^port: / {
+			if( NF > 6 ) {
+				if( target == $2 ) {
+					print $5, sw;
+					exit( 0 )
+				}
+			}
+		}
+	' | read mac sw
+
+	if [[ -z $sw ]]
+	then
+		echo "$1" ""
+	fi
+
+	echo "$mac" "$sw"
+}
+
+# Accept proto:[address:]port and split them echoing three strings: proto, addr, port
+# if address is missing the string 'none' is echoed. The global variable ip_type is set
+# based on the address type and left alone if just the port was supplied.
+function split_pap
+{
+	typeset proto=${1%%:*}		# strip off protocol
+	typeset rest=${1#*:}		# address:port or just port
+
+	if [[ -z $rest ]]			# only proto given
+	then
+		echo "$proto none 0"
+	fi
+
+	case $rest in 
+		\[*\]:)					# ipv6 address:port
+			typeset addr="${rest%%]*}"
+			ip_type="-6"								# must force the type; set directly, DO NOT use set_ip_type
+			echo "$proto ${addr##*\[} ${rest##*]:}"
+			;;
+
+		\[*)					# ipv6 address
+			typeset addr="${rest%%]*}"
+			ip_type="-6"
+			echo "$proto ${addr##*\[} 0"
+			;;
+
+		*.*.*.*:)					# ipv4:port
+			ip_type="-4"
+			echo "$proto ${rest%%:*} ${rest##*:}"
+			;;
+
+		*.*.*.*)					# ipv4
+			ip_type="-4"
+			echo "$proto ${rest%%:*} 0"
+			;;
+
+		*)						# just port; default ip type, or what they set on command line
+			echo "$proto none ${rest//:/}"
+			;;
+	esac
+}
+
+# check the current setting of ip_type and return $1 only if it's not set. If it's set
+# return the current setting.  This prevents ip_type from being set by the pap function 
+# and then incorrectly overridden from a comand line option.
+function set_ip_type
+{
+	if [[ -n $ip_type ]]
+	then
+		echo $ip_type
+	else
+		echo "$1" 
+	fi
+}
+
+# ----------------------------------------------------------------------------------------------------------
+
+cookie="0x0dad"			# static for now, but might want to make them user controlled, so set them up here
+bridge="br-int"
+
+smac=""					# src mac address (local to this OVS)
+forreal=""
+to_value=60				# default timeout value
+timout="-t $to_value"	# timeout parm given on command if -t not supplied
+operation="add"			# -X sets delete action
+ip_type=""				# default unless we see a specific address
+
+while [[ $1 == -* ]]
+do
+	case $1 in
+		-4)		ip_type="$(set_ip_type $2);;				# set if not set; don't let them override what was set in pap
+		-6)		ip_type="$(set_ip_type $2);;				# set if not set; don't let them override what was set in pap
+		-n)		forreal="-n";;
+		-s)		smac="$2"; shift;;						# source (local) mac address (should be endpoint to be safe, but allow mac)
+		-S)		split_pap "$2" | read proto sip port	# expect -S {udp|tcp}:[address:]port
+				if [[ $sip == "none" ]]
+				then
+					sip=""
+				else
+					sip="-S $sip" 
+				fi
+				shift
+				;;
+
+		-t)		to_value=$2; timeout="-t $2"; shift;;	# capture both the value for math, and an option for flow-mod call
+		-T)		odscp="-T $2"; shift;;
+		-X)		operation="del";;
+
+		-\?)	usage
+				exit 0
+				;;
+
+		*)	echo "unrecognised option: $1"
+			usage
+			exit 1
+			;;
+	esac
+
+	shift
+done
+
+if [[ -z $smac ]]
+then
+	logit "must have source endpoint (better) or mac address (unsafe) in order to generate passthrough flow-mods   [FAIL]"
+	exit 1
+fi
+
+ep2mac $smac | read ep_mac ep_switch	# convert endpoint to mac, and the get bridge name (if it is an endpoint)
+if [[ -n $ep_switch ]]					# it converted if switch isn't blank
+then
+	logit "endpoint $smac converted to mac/switch: $ep_mac/$ep_switch	[INFO]"
+	smac=$ep_mac
+	bridge=$ep_switch
+else
+	logit "$smac seems not to be an endpoint, used directly with bridge $bridge	[INFO]"
+fi
+
+if false
+then
+if [[ -n $sproto && -z sip ]]			# must have a source IP if source proto is supplied
+then
+	logit "source IP address (-S) required when prototype (-p) is supplied   [FAIL]"
+	exit 1
+fi
+fi
+
+if [[ -n $proto ]]
+then
+	proto="-p $proto:$port"
+fi
+
+# the flow-mod is simple; match and set marking that causes the p10 flow-mod from matching.
+set -x
+send_ovs_fmod $forreal $timeout -p 400 --match -m 0x0/0x7 $sip -s $smac $proto --action  -M 0x01  -R ,0 -N $operation $cookie $bridge
+rc=$(( rc + $? ))
+set +x
+
+rm -f /tmp/PID$$.*
+if (( rc ))
+then
+	exit 1
+fi
+
+exit 0

--- a/gizmos/gizmos_pt_test.go
+++ b/gizmos/gizmos_pt_test.go
@@ -1,0 +1,104 @@
+// vi: sw=4 ts=4:
+/*
+ ---------------------------------------------------------------------------
+   Copyright (c) 2013-2015 AT&T Intellectual Property
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at:
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ ---------------------------------------------------------------------------
+*/
+
+
+/*
+
+	Mnemonic:	gizmos_pledge_pt_test
+	Abstract:	test some of the pasthrough pledge functions.
+	Date:		26 March 2015
+	Author:		E. Scott Daniels
+
+*/
+
+package gizmos_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/att/tegu/gizmos"
+)
+
+const (
+)
+
+// ---- support -----------------------------------------------------------------------
+
+
+// --- tests --------------------------------------------------------------------------
+func TestPass_pledge( t *testing.T ) {
+
+	fmt.Fprintf( os.Stderr, "\n------- make passthrou pledge -----------\n" )
+	host := "host"
+	port := "7890"
+	commence := time.Now().Unix() + 3600
+	expiry := int64( commence + 45 )
+	id := "res-test-pass-pledge"
+	ukey := "my-cookie"
+	
+	ppt1, err := gizmos.Mk_pass_pledge( &host, &port, commence, expiry, &id, &ukey )
+	if err != nil {
+		fmt.Fprintf( os.Stderr, "cannot make pass pledge; all other passthrough tests aborted: %s	[FAIL]\n", err )
+		t.Fail()
+		return
+	}
+	fmt.Fprintf( os.Stderr, "mk successful\n" );
+
+	pptc := ppt1.Clone( "cloned" )
+	if pptc == nil {
+		fmt.Fprintf( os.Stderr, "cannot clone pass pledge; all other passthrough tests aborted	[FAIL]\n" )
+		t.Fail()
+		return
+	}
+	fmt.Fprintf( os.Stderr, "clone successful\n" );
+	
+	host2 := "host2"
+	port2 := "7890"
+	id2 := "res-test-pass-pledge2"
+	ukey2 := "my-cookie"
+	ppt2, err := gizmos.Mk_pass_pledge( &host2, &port2, commence, expiry, &id2, &ukey2 ) 
+	if err != nil {
+		fmt.Fprintf( os.Stderr, "cannot make second pass pledge; all other passthrough tests aborted: %s	[FAIL]\n", err )
+		t.Fail()
+		return
+	}
+
+	gp := gizmos.Pledge( pptc )			// must convert to a generic pledge so we can take address off next
+	if ppt1.Equals( &gp ) {
+		fmt.Fprintf( os.Stderr, "clone reports equal [OK]\n" )
+	} else {
+		fmt.Fprintf( os.Stderr, "clone reports !equal [FAIL]\n" )
+	}
+
+	gp = gizmos.Pledge( ppt2 )			// must convert to a generic pledge so we can take address off next
+	if ppt1.Equals(  &gp ) {
+		fmt.Fprintf( os.Stderr, "second pledge reports equal [FAIL]\n" )
+	} else {
+		fmt.Fprintf( os.Stderr, "second pledge reports !equal [OK]\n" )
+	}
+
+
+	fmt.Fprintf( os.Stderr, "json:   %s\n", ppt1.To_json() )
+	fmt.Fprintf( os.Stderr, "string: %s\n", ppt1 )
+	fmt.Fprintf( os.Stderr, "chkpt: %s\n", ppt1.To_chkpt() )
+
+}

--- a/gizmos/init.go
+++ b/gizmos/init.go
@@ -41,11 +41,15 @@ import (
 
 //import "github.com/att/tegu"
 
+// DANGER:  do NOT change the order of these as the values end up hard coded in the checkpoint file
+//			once datacache is implemented there is no danger, but until then bad things will happen
+//			if the order is not preserved.  Add new ones to the end!
 const (
 	PT_BANDWIDTH	int = iota				// pledge types
 	PT_STEERING
 	PT_MIRRORING
 	PT_OWBANDWIDTH							// one way bandwidth
+	PT_PASSTHRU								// passthrough dscp marking reservation
 )
 
 var (

--- a/gizmos/pledge.go
+++ b/gizmos/pledge.go
@@ -120,12 +120,16 @@ func Json2pledge( jstr *string ) ( p *Pledge, err error ) {
 					mp.From_json( jstr )
 					pi = Pledge( mp )			// convert to interface type
 					
-	
 				case PT_STEERING:
 					mp := new( Pledge_steer )
 					mp.From_json( jstr )
 					pi = Pledge( mp )			// convert to interface type
 	
+				case PT_PASSTHRU:
+					pt := new( Pledge_pass )
+					pt.From_json( jstr )
+					pi = Pledge( pt )			// convert to interface type
+
 				default:
 					err = fmt.Errorf( "unknown pledge type in json: %d: %s", *jp.Ptype, *jstr )
 					return

--- a/gizmos/pledge_pass.go
+++ b/gizmos/pledge_pass.go
@@ -1,0 +1,389 @@
+// vi: sw=4 ts=4:
+/*
+ ---------------------------------------------------------------------------
+   Copyright (c) 2013-2015 AT&T Intellectual Property
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at:
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ ---------------------------------------------------------------------------
+*/
+
+
+/*
+
+	Mnemonic:	pledge_pass
+	Abstract:	Passthrough pledge. Manages a reservation which allows user set DSCP markings
+				to pass through the flow-mods that Tegu (agent) sets to mark non-reservation 
+				traffic DSCP to 0.
+	Date:		26 Jan 2016
+	Author:		E. Scott Daniels
+
+	Mods:
+*/
+
+package gizmos
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/att/gopkgs/clike"
+)
+
+type Pledge_pass struct {
+				Pledge_base	// common fields
+	host		*string		// VM (endpoint) where the traffic originates from
+	protocol	*string		// tcp/udp:port
+	tpport		*string		// transport port number or 0 if not defined
+	vlan		*string		// vlan id to match with h1 match criteria
+}
+
+/*
+	A work struct used to decode a json string using Go's json package which requires things to
+	be exported (boo). We need this to easily parse the json saved in the checkpoint file.
+	We assume that host1/2 are saved _with_ trailing :port and thus we don't explicitly save/restore
+	the tp port fields.  The conversion from checkpoint value to full struct will split them off.
+*/
+type Json_pledge_pass struct {
+	Host		*string
+	Protocol	*string
+	Commence	int64
+	Expiry		int64
+	Usrkey		*string
+	Id			*string
+	Ptype		int
+}
+
+// ---- private -------------------------------------------------------------------
+
+/*
+	Returns {ID} if the vlan is defined and > 0. Returns an empty string if not 
+	defined, or invalid value.
+*/
+func ( p *Pledge_pass ) vlan2string( ) (vlan string ) {
+	vlan = ""
+	if p.vlan != nil && clike.Atoi( *p.vlan ) > 0 {
+		vlan = "{" + *p.vlan + "}"
+	}
+
+	return vlan
+}
+
+// ---- public -------------------------------------------------------------------
+
+/*
+	Constructor; creates a pledge.
+	Creates a passthrough pledge allowing traffic from the indicated host to mark its own traffic with 
+	the desired DSCP markings.
+
+	A nil pointer is returned if the expiry time is in the past and the commence time is adjusted forward
+	(to the current time) if it is less than the current time.
+*/
+func Mk_pass_pledge( host *string,  port *string, commence int64, expiry int64, id *string, usrkey *string ) ( p *Pledge_pass, err error ) {
+
+	err = nil
+	p = nil
+
+	window, err := mk_pledge_window( commence, expiry )		// make the window and error if commence after expiry
+	if err != nil {
+		return
+	}
+
+	if id == nil {
+		dummy := "unnamed-pt-pledge"
+		id = &dummy
+	}
+
+	p = &Pledge_pass {
+		Pledge_base:Pledge_base{
+			id: id,
+			window: window,
+		},
+		host: host,
+		tpport: port,
+		protocol:	&empty_str,
+	}
+
+	if usrkey != nil && *usrkey != "" {
+		p.usrkey = usrkey
+	} else {
+		p.usrkey = &empty_str
+	}
+
+	return p, nil
+}
+
+/*
+	Return whether the match on IPv6 flag is true
+func (p *Pledge_pass) Get_matchv6() ( bool ) {
+	return p.match_v6
+}
+*/
+
+
+/*
+	Returns pointers to host string (name is plural becaues that's defined in the pledge interface).
+	The interface demands two values back so we send a dummy value to keep it happy.
+	TODO: We should change the interface to return an array.
+*/
+func (p *Pledge_pass) Get_hosts( ) ( host *string, dummy *string ) {
+	if p == nil {
+		return &empty_str, &empty_str
+	}
+
+	return p.host, &empty_str
+}
+
+/*
+	Returns the set of values that are needed to create a pledge in the network:
+		pointer to host name,
+		the host transport port number and mask or ""
+		the commence time,
+		the expiry time
+*/
+func (p *Pledge_pass) Get_values( ) ( host *string,  port *string, commence int64, expiry int64 ) {
+	if p == nil {
+		return &empty_str, &empty_str, 0, 0
+	}
+
+	c, e := p.window.get_values()
+	return p.host,  p.tpport, c, e
+}
+
+/*
+	Set the vlan IDs associated with the hosts (for matching)
+*/
+func (p *Pledge_pass) Set_vlan( vlanid *string ) {
+	if p == nil {
+		return
+	}
+
+	p.vlan = vlanid
+}
+
+/*
+	Returns the matching vlan IDs.
+*/
+func (p *Pledge_pass) Get_vlan( ) ( vlanid *string ) {
+	if p == nil {
+		return
+	}
+
+	return p.vlan
+}
+
+/*
+	Create a clone of the pledge.  The path is NOT a copy, but just a reference to the list
+	from the original.
+*/
+func (p *Pledge_pass) Clone( name string ) ( *Pledge_pass ) {
+	newp := &Pledge_pass {
+		Pledge_base:Pledge_base {
+			id:			&name,
+			usrkey:		p.usrkey,
+			pushed:		p.pushed,
+			paused:		p.paused,
+		},
+		host:		p.host,
+		tpport: 	p.tpport,
+		protocol: 	p.protocol,
+	}
+
+	newp.window = p.window.clone()
+	return newp
+}
+
+/*
+	Accepts another pledge (op) and compares the two returning true if the following values are
+	the same:
+		hosts, protocol, transport ports, vlan match value, window
+
+	The test for window involves whether the reservation overlaps. If there is any
+	overlap they are considered equal windows, otherwise not.
+
+	It gets messy.... if p1.h1 == p2.h2 (hosts reversed), then we must match the
+	reverse of port since port and host must align.
+*/
+func (p *Pledge_pass) Equals( op *Pledge ) ( state bool ) {
+
+	if p == nil {
+		return false
+	}
+
+	opt, ok := (*op).( *Pledge_pass )			// convert from generic type to specific
+	if ok {
+		if ! Strings_equal( p.protocol, opt.protocol ) { return false }
+		if ! Strings_equal( p.host, opt.host ) { return false }
+		if ! Strings_equal( p.tpport, opt.tpport ) { return false }
+		if ! Strings_equal( p.vlan, opt.vlan ) { return false }
+
+		if ! p.window.overlaps( opt.window ) { return false; }
+
+		return true							// get here, all things are the same
+	}
+
+	return false
+}
+
+// --------------- interface functions (required) ------------------------------------------------------
+/*
+	Destruction
+*/
+func (p *Pledge_pass) Nuke( ) {
+	return
+	p.host = nil
+	p.id = nil
+	p.usrkey = nil
+}
+
+/*
+	Given a json string unpack it and put it into a pledge struct.
+	We assume that the host names are name:port and split them apart
+	as would be expected.
+*/
+func (p *Pledge_pass) From_json( jstr *string ) ( err error ){
+	jp := new( Json_pledge_pass )
+	err = json.Unmarshal( []byte( *jstr ), &jp )
+	if err != nil {
+		return
+	}
+
+	if jp.Ptype != PT_PASSTHRU {
+		err = fmt.Errorf( "json was not a passthrough pledge type type=%d", jp.Ptype )
+		return
+	}
+
+	p.host, p.tpport, p.vlan  = Split_hpv( jp.Host )		// suss apart host and port
+	p.protocol = jp.Protocol
+	p.window, _ = mk_pledge_window( jp.Commence, jp.Expiry )
+	p.id = jp.Id
+	p.usrkey = jp.Usrkey
+	p.protocol = jp.Protocol
+	if p.protocol == nil {					// we don't tolerate nil ptrs
+		p.protocol = &empty_str
+	}
+
+	return
+}
+
+// --- functions that extend the interface -- pass-only functions ---------
+/*
+	Add a protocol reference to the pledge (e.g. tcp:80 or udp:4444)
+*/
+func (p *Pledge_pass) Add_proto( proto *string ) {
+	if p == nil {
+		return
+	}
+
+	p.protocol = proto
+}
+
+/*
+	Return the protocol associated with the pledge.
+*/
+func (p *Pledge_pass) Get_proto( ) ( *string ) {
+	return p.protocol
+}
+
+// --- functions required by the interface ------------------------------
+/*
+	Set match v6 flag based on user input.
+*/
+func (p *Pledge_pass) Set_matchv6( state bool ) {
+}
+
+
+/*
+	Accepts a host name and returns true if it matches either of the names associated with
+	this pledge.
+*/
+func (p *Pledge_pass) Has_host( hname *string ) ( bool ) {
+	return *p.host == *hname
+}
+
+
+// --------- humanisation or export functions --------------------------------------------------------
+
+/*
+	return a nice string from the data.
+	(Deprecated in favour of Stringer interface)
+*/
+func (p *Pledge_pass) To_str( ) ( s string ) {
+	return p.String()
+}
+
+/*
+	Stringer interface so that fmt.Printf( "%s\n", p ) will just work.
+*/
+func (p *Pledge_pass) String( ) ( s string ) {
+
+	if p == nil {
+		return ""
+	}
+
+	state, caption, diff := p.window.state_str()
+	commence, expiry := p.window.get_values( )
+	v := p.vlan2string( )
+
+	//NEVER put the usrkey into the string!
+	s = fmt.Sprintf( "%s: togo=%ds %s h=%s:%s%s id=%s st=%d ex=%d push=%v ptype=passthrough", state, diff, caption, *p.host, *p.tpport, v, *p.id, commence, expiry, p.pushed )
+	return
+}
+
+/*
+	Generate a json representation of the pledge. This is different than the checkpoint
+	string as it is safe to use this in a reservation list that will be presented to
+	some user -- no cookie or other 'private' information should be exposed in the
+	json generated here.
+	We do NOT use the json package because we don't put the object directly in; we render
+	useful information, which excludes some of the raw data, and we don't want to have to
+	expose the fields publicly that do go into the json output.
+*/
+func (p *Pledge_pass) To_json( ) ( json string ) {
+	if p == nil {
+		return "{ }"
+	}
+
+	state, _, diff := p.window.state_str()		// get state as a string
+	v := p.vlan2string( )
+
+	json = fmt.Sprintf( `{ "state": %q, "time": %d, "host": "%s:%s%s", "id": %q, "ptype": %d }`, state, diff, *p.host, *p.tpport, v, *p.id,  PT_PASSTHRU )
+
+	return
+}
+
+/*
+	Build a checkpoint string -- probably json, but it will contain everything including the user key.
+	We still won't use the json package because that means making all of the fields available to outside
+	users.
+
+	If the pledge is expired, the string "expired" is returned which seems a bit better than just returning
+	an empty string, or "{ }" which is meaningless.
+
+	The kind value is a constant that allows the user to know what kind of pledge this is for easy reload
+	without having to blindly unbundle the json into all possible pledge types to discover the type. The
+	type _is_ put into the json for error checking internally.
+*/
+func (p *Pledge_pass) To_chkpt( ) ( chkpt string ) {
+
+	if p.Is_expired( ) {			// will show expired if p is nil, so safe without check
+		chkpt = "expired"
+		return
+	}
+
+	commence, expiry := p.window.get_values()
+	v := p.vlan2string( )
+
+	chkpt = fmt.Sprintf( `{ "host": "%s:%s%s", "commence": %d, "expiry": %d, "id": %q, "usrkey": %q, "ptype": %d }`, *p.host, *p.tpport, v, commence, expiry, *p.id, *p.usrkey, PT_PASSTHRU )
+
+	return
+}

--- a/gizmos/pledge_window.go
+++ b/gizmos/pledge_window.go
@@ -36,7 +36,6 @@
 package gizmos
 
 import (
-	"os"
 	"fmt"
 	"time"
 )
@@ -291,7 +290,6 @@ func (p *pledge_window) is_extinct( window int64 ) ( bool ) {
 */
 func (p *pledge_window) overlaps( p2 *pledge_window ) ( bool ) {
 	if p == nil || p2 == nil {
-fmt.Fprintf( os.Stderr, ">>>> one/both are nil %v | %v\n", p, p2 )
 		return false
 	}
 

--- a/main/tegu.go
+++ b/main/tegu.go
@@ -141,6 +141,7 @@
 				16 Dec 2015 : Strips domain from phys host names for path finding
 				17 Dec 2015 : Lists only L3 nodes for network hosts.
 				09 Jan 2016 : Bump version (added more options for add-mirror)
+				28 Jan 2015 : Added passthru reservation support.
 
 	Version number "logic":
 				3.0		- QoS-Lite version of Tegu
@@ -175,7 +176,7 @@ func usage( version string ) {
 
 func main() {
 	var (
-		version		string = "v3.1.5/11096"		// 3.1.x == steering branch version (.2 steering only, .3 steering+mirror+lite)
+		version		string = "v3.1.5/11286"		// 3.1.x == steering branch version (.2 steering only, .3 steering+mirror+lite)
 		cfg_file	*string  = nil
 		api_port	*string						// command line option vars must be pointers
 		verbose 	*bool

--- a/managers/fq_mgr.go
+++ b/managers/fq_mgr.go
@@ -741,6 +741,11 @@ func Fq_mgr( my_chan chan *ipc.Chmsg, sdn_host *string ) {
 				send_bw_fmods( fdata, ip2mac, phost_suffix )
 				msg.Response_ch = nil					// nothing goes back from this
 
+			case REQ_PT_RESERVE:						// DSCP passthru flow-mods need to be generated
+				fdata = msg.Req_data.( *Fq_req );
+				send_pt_fmods( fdata, ip2mac, phost_suffix )
+				msg.Response_ch = nil
+
 			case REQ_IE_RESERVE:						// proactive ingress/egress reservation flowmod  (this is likely deprecated as of 3/21/2015 -- resmgr invokes the bw_fmods script via agent)
 				fdata = msg.Req_data.( *Fq_req ); 		// user view of what the flow-mod should be
 

--- a/managers/fq_pass.go
+++ b/managers/fq_pass.go
@@ -1,0 +1,93 @@
+// vi: sw=4 ts=4:
+/*
+ ---------------------------------------------------------------------------
+   Copyright (c) 2013-2015 AT&T Intellectual Property
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at:
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ ---------------------------------------------------------------------------
+*/
+
+
+/*
+	Mnemonic:	fq_mgr_pass
+	Abstract:	flow/queue manager passthrough reservation related things.
+
+	Date:		26 January 2016
+	Author:		E. Scott Daniels
+
+	Mods:
+*/
+
+package managers
+
+import (
+	"encoding/json"
+
+	"github.com/att/gopkgs/ipc"
+)
+
+
+/*
+	Send a passthrough flowmod generation request to the agent manager.
+	This is basically taking the struct that the reservation manager 
+	filled in and converting it to a map.
+
+	Send a bandwidth endpoint flow-mod request to the agent manager.
+	This is little more than a wrapper that converts the fq_req into
+	an agent request. The ultimate agent action is to put in all
+	needed flow-mods on an endpoint host in one go, so no need for
+	individual requests for each and no need for tegu to understand
+	the acutal flow-mod mechanics any more.
+
+	Yes, this probably _could_ be pushed up into the reservation manager
+	and sent from there to the agent manager, but for now, since the
+	ip2mac information is local to fq-mgr, we'll keep it here.  (That
+	info is local to fq-mgr b/c in the original Tegu it came straight
+	in from skoogi and it was fq-mgr's job to interface with skoogi.)
+*/
+func send_pt_fmods( data *Fq_req, ip2mac map[string]*string, phost_suffix *string ) {
+
+
+	if *data.Swid == "" {									// we must have a switch name to set bandwidth fmods
+		fq_sheep.Baa( 1, "unable to send passthrough fmod request to agent: no switch defined in input data" )
+		return
+	}
+
+	host := data.Swid
+	if phost_suffix != nil {									// we need to add the physical host suffix
+		host = add_phost_suffix( host, phost_suffix )
+	}
+
+	if data.Match.Smac != nil {									// caller can pass in IP and we'll convert it
+		if ip2mac[*data.Match.Smac] != nil {
+			data.Match.Smac = ip2mac[*data.Match.Smac]			// res-mgr thinks in IP, flow-mods need mac; convert
+		}
+	}
+
+	msg := &agent_cmd{ Ctype: "action_list" }					// create a message for agent manager to send to an agent
+	msg.Actions = make( []action, 1 )							// just a single action
+	msg.Actions[0].Atype = "passthru"							// set all related passthrough flow-mods
+	msg.Actions[0].Hosts = make( []string, 1 )					// passthrough flow-mods created on just one host
+	msg.Actions[0].Hosts[0] = *host
+	msg.Actions[0].Data = data.To_pt_map()						// convert useful data from caller into parms for agent
+
+	json, err := json.Marshal( msg )							// bundle into a json string
+	if err != nil {
+		fq_sheep.Baa( 0, "unable to build json to set passthrough flow-mods" )
+	} else {
+		tmsg := ipc.Mk_chmsg( )
+		tmsg.Send_req( am_ch, nil, REQ_SENDSHORT, string( json ), nil )		// send as a short request to one agent
+	}
+
+	fq_sheep.Baa( 2, "passthru flow-mod request sent to agent manager: %s", json )
+}

--- a/managers/fq_req.go
+++ b/managers/fq_req.go
@@ -241,7 +241,38 @@ func ( fq *Fq_req ) To_bwow_map( ) ( fmap map[string]string ) {
 
 	if fq_sheep.Would_baa( 2 ) {
 		for k, v := range fmap {
-			fq_sheep.Baa( 2, "fq_req to action id=%s %s = %s", fq.Id, k, v )
+			fq_sheep.Baa( 2, "fq_req to action id=%s %s = %s", *fq.Id, k, v )
+		}
+	}
+
+	return
+}
+
+/*
+	Build a map suitable for use as parms for a passthrough request to the agent manager.
+			build_opt( parms["smac"], "-s" ) +				// smac can (and should) be an endpoint UUID which is converted to mac/bridge on the host
+			build_opt( parms["sip"], "-S" ) +				// sip is [proto:][addr:][port] where either proto or address must be supplied
+			build_opt( parms["timeout"],  "-t" )
+*/
+func ( fq *Fq_req ) To_pt_map( ) ( fmap map[string]string ) {
+	fmap = make( map[string]string )
+
+	if fq == nil {
+		return
+	}
+
+	if fq.Match.Smac != nil {					// could be endpoint, but likely mac in the original Tegu.
+		fmap["smac"] = *fq.Match.Smac
+	} else {
+		fmap["smac"] = ""						// agent likely to barf on this
+	}
+
+	fmap["timeout"] =  fmt.Sprintf( "%d", fq.Expiry - time.Now().Unix() )
+	fmap["sip"] = *fq.Match.Ip1								// will be [{udp|tcp}:]address[:port]
+
+	if fq_sheep.Would_baa( 3 ) {
+		for k, v := range fmap {
+			fq_sheep.Baa( 3, "to_pt_map: fq_req value -> action id=%s %s = %s", *fq.Id, k, v )
 		}
 	}
 

--- a/managers/globals.go
+++ b/managers/globals.go
@@ -156,6 +156,7 @@ const (
 	REQ_SWITCHINFO				// request switch info from all hosts
 	REQ_GENPLAN					// (re)generate a steering plan for a new/modified chain request
 	REQ_PT_RESERVE				// passthru reservation
+	REQ_GETULCAP				// get the current user limit cap maximum value
 )
 
 const (

--- a/managers/globals.go
+++ b/managers/globals.go
@@ -156,7 +156,6 @@ const (
 	REQ_SWITCHINFO				// request switch info from all hosts
 	REQ_GENPLAN					// (re)generate a steering plan for a new/modified chain request
 	REQ_PT_RESERVE				// passthru reservation
-	REQ_GETULCAP				// get the current user limit cap maximum value
 )
 
 const (

--- a/managers/globals.go
+++ b/managers/globals.go
@@ -155,6 +155,7 @@ const (
 	REQ_DUPCHECK				// check for duplicate (resmgr)
 	REQ_SWITCHINFO				// request switch info from all hosts
 	REQ_GENPLAN					// (re)generate a steering plan for a new/modified chain request
+	REQ_PT_RESERVE				// passthru reservation
 )
 
 const (

--- a/managers/http_api.go
+++ b/managers/http_api.go
@@ -97,6 +97,7 @@
 				12 Aug 2015 : Corrected debug message.
 				03 Sep 2015 : Added latency option to verbose.
 				12 Nov 2015 : Pulled in httplogger from steering branch.
+				27 Jan 2016 : Added support for passthrough reservations.
 */
 
 package managers
@@ -138,7 +139,7 @@ func mk_resname( ) ( string ) {
 }
 
 /*
-	Validate the h1 and h2 strings translating the project name to a tenant ID if present.
+	Validate the h1 and optionally h2 strings translating the project name to a tenant ID if present.
 	The translated names are returned if _both_ are valid; error is set otherwise.
 	In addition, if a port number is added to a host name it is stripped and returned.
 
@@ -195,6 +196,33 @@ func validate_hosts( h1 string, h2 string ) ( h1x string, h2x string, p1 *string
 	}
 
 	return
+}
+
+/*	This is almost identical to validate_hosts() for a single host.  It does not support
+	'external' host names. The host name is expected to be project/host[:port][{vlan}].
+	If a project name is given, it is translated to project ID and reflected in the 
+	hostx (extracted) string. If port and vlan are embedded, they are stripped and 
+	returned as separater values.
+*/
+func validate_one_host( hname string ) ( hostx string, port *string, vlan *string, err error ) {
+	var ht *string
+
+	my_ch := make( chan *ipc.Chmsg )							// allocate channel for responses to our requests
+	port = &zero_string
+
+	req := ipc.Mk_chmsg( )
+	req.Send_req( osif_ch, my_ch, REQ_VALIDATE_HOST, &hname, nil )	// request to openstack interface to validate this token/project pair for host
+	req = <- my_ch													// hard wait for response
+
+	if req.State != nil {
+		err = fmt.Errorf( "h1 validation failed: %s", req.State )
+		return
+	}
+
+	ht, port, vlan = gizmos.Split_hpv( req.Response_data.( *string ) ) 	// split off :port from token/project/name where name is name or address
+	hostx = *ht
+
+	return hostx, port, vlan, err
 }
 
 
@@ -513,6 +541,72 @@ func finalise_bwow_res( res *gizmos.Pledge_bwow, res_paused bool ) ( reason stri
 }
 
 
+
+/*	Given a passthrough reservation (pledge) get the physical host for the reseration and then send the reservation off to 
+	reservation manager to do the rest (push flow-mods etc.)  The return values may seem odd, but are a result of 
+	breaking this out of the main parser which wants two reason strings and a count of errors in order to report 
+	an overall status and a status of each request that was received from the outside world.
+
+	This function will also check for a duplicate pledge already in the inventory and reject it
+	if a dup is found.
+*/
+func finalise_pt_res( res *gizmos.Pledge_pass, res_paused bool ) ( reason string, jreason string, nerrors int ) {
+
+	nerrors = 0
+	jreason = ""
+	reason = ""
+
+	my_ch := make( chan *ipc.Chmsg )						// allocate channel for responses to our requests
+	defer close( my_ch )									// close it on return
+
+	req := ipc.Mk_chmsg( )
+	gp := gizmos.Pledge( res )								// convert to generic pledge to pass
+	req.Send_req( rmgr_ch, my_ch, REQ_DUPCHECK, &gp, nil )	// see if we have a duplicate in the cache
+	req = <- my_ch											// get response from the network thread
+	if req.Response_data != nil {							// response is a pointer to string, if the pointer isn't nil it's a dup
+		rp := req.Response_data.( *string )
+		if rp != nil {
+			nerrors = 1
+			reason = fmt.Sprintf( "reservation duplicates existing reservation: %s",  *rp )
+			return
+		}
+	}
+
+	host, _ := res.Get_hosts()
+	rm_sheep.Baa( 1, "requesting phys host for: %s\n", *host )
+	req = ipc.Mk_chmsg( )
+	req.Send_req( nw_ch, my_ch, REQ_GETPHOST, host, nil )	// send to network to translate the VM ID into a physical host name
+	req = <- my_ch											// get response from the network thread
+
+	if req.Response_data != nil {
+		phost := req.Response_data.( *string )
+		res.Set_phost( phost )
+
+		req.Send_req( rmgr_ch, my_ch, REQ_ADD, res, nil )	// network OK'd it, so add it to the inventory
+		req = <- my_ch										// wait for completion
+
+		if req.State == nil {
+			ckptreq := ipc.Mk_chmsg( )
+			ckptreq.Send_req( rmgr_ch, nil, REQ_CHKPT, nil, nil )	// request a chkpt now, but don't wait on it
+			reason = fmt.Sprintf( "passthru reservation accepted" )
+			jreason =  res.To_json()
+		} else {
+			nerrors++
+			reason = fmt.Sprintf( "%s", req.State )
+		}
+
+		if res_paused {
+			rm_sheep.Baa( 1, "reservations are paused, passthru reservation accepted reservation will not be pushed until resumed" )
+			res.Pause( false )								// when paused we must mark the reservation as paused and pushed so it doesn't push until resume received
+			res.Set_pushed( )
+		}
+	} else {
+		reason = fmt.Sprintf( "passthru reservation rejected: %s", req.State )
+		nerrors++
+	}
+
+	return
+}
 
 
 // ---- main parsers ------------------------------------------------------------------------------------
@@ -972,6 +1066,50 @@ func parse_post( out http.ResponseWriter, recs []string, sender string, xauth st
 							}
 						}
 					}
+
+				case "passthru":
+					var res *gizmos.Pledge_pass
+
+						key_list := "window host cookie"						// positional parameters supplied after any key/value pairs
+						tmap := gizmos.Mixtoks2map( tokens[1:], key_list )		// map tokens in order key list names allowing key=value pairs to precede them and define optional things
+						ok, mlist := gizmos.Map_has_all( tmap, key_list )		// check to ensure all expected parms were supplied
+						if !ok {
+							nerrors++
+							reason = fmt.Sprintf( "missing parameters: (%s); usage: passthru {[<start>-]<end-time>|+sec} <host1> cookie; received: %s", mlist, recs[i] );
+							break
+						}
+
+						startt, endt = gizmos.Str2start_end( *tmap["window"] )		// split time token into start/end timestamps
+						host := *tmap["host"]											// get the host (VM) name
+
+						res = nil
+						host, port, vlan, err := validate_one_host( host )			// translate project/host[:port][{vlan}] into pieces parts and validates token/project
+
+						if err == nil {
+							update_graph( &host, true, true )						// pull all of the VM information from osif then send to fqmgr and netmgr (block until netmgr accepts it)
+
+							res_name := mk_resname( )								// name used to track the reservation in the cache and given to queue setting commands for visual debugging
+							res, err = gizmos.Mk_pass_pledge( &host,  port, startt, endt, &res_name, tmap["cookie"] )
+						}
+
+						if res != nil {												// able to make the reservation, continue and try to find a path with bandwidth
+							res.Set_vlan( vlan )									// augment the rest of the reservation
+							if tmap["prot"] != nil {
+								res.Set_proto( tmap["proto"] )
+							}
+
+							reason, jreason, ecount = finalise_pt_res( res, res_paused )			// check for dup, allocate in network, and add to res manager inventory
+							if ecount == 0 {
+								state = "OK"
+							} else {
+								nerrors += ecount - 1 												// number of errors added to the pile by the call
+							}
+						} else {
+							if err == nil {
+								err = fmt.Errorf( "specific reason unknown" )						// ensure we have something for message
+							}
+							reason = fmt.Sprintf( "reservation rejected: %s", err )
+						}
 
 			case "steer":								// parse a steering request and make it happen
 					var res *gizmos.Pledge_steer

--- a/managers/res_mgr.go
+++ b/managers/res_mgr.go
@@ -99,6 +99,7 @@
 						command to be run and it wasn't.)
 				08 Sep 2015 : Prevent checkpoint files from being written in the same second (gh#22).
 				08 Oct 2015 : Added !pushed check back to active reservation pushes.
+				27 Jan 2015 : Changes to support passthru reservations.
 */
 
 package managers
@@ -176,7 +177,9 @@ func name2ip( name *string ) ( ip *string ) {
 	msg = <- ch
 	if msg.State == nil {					// success
 		ip = msg.Response_data.(*string)
-	}
+	} else {
+rm_sheep.Baa( 1, ">>>>> name didn't translate to ip: %s", name )
+}
 
 	return
 }
@@ -360,6 +363,9 @@ func (i *Inventory) push_reservations( ch chan *ipc.Chmsg, alt_table int, hto_li
 
 						case *gizmos.Pledge_mirror:
 							push_mirror_reservation( p, rname, ch )
+
+						case *gizmos.Pledge_pass:
+							pass_push_res( p, &rname, ch, hto_limit )
 					}
 
 					pushed_count++
@@ -525,7 +531,7 @@ func (i *Inventory) load_chkpt( fname *string ) ( err error ) {
 									req = <- my_ch										// should be OK, but the underlying network could have changed
 
 									if req.Response_data != nil {
-										gate := req.Response_data.( *gizmos.Gate  )			// expect that network sent us a gate
+										gate := req.Response_data.( *gizmos.Gate )		// expect that network sent us a gate
 										sp.Set_gate( gate )
 										rm_sheep.Baa( 1, "gate allocated for oneway reservation: %s %s %s %s", *(sp.Get_id()), *h1, *h2, *(gate.Get_extip()) )
 										err = i.Add_res( p )
@@ -550,6 +556,27 @@ func (i *Inventory) load_chkpt( fname *string ) ( err error ) {
 									} else {
 										rm_sheep.Baa( 0, "ERR: resmgr: ckpt_laod: unable to reserve for pledge: %s	[TGURMG000]", (*p).To_str() )
 									}
+
+								case *gizmos.Pledge_pass:
+									host, _ := sp.Get_hosts()
+									update_graph( host, true, true )
+									req.Send_req( nw_ch, my_ch, REQ_GETPHOST, host, nil )		// need to find the current phost for the vm
+									req = <- my_ch
+
+									if req.Response_data != nil {
+										phost := req.Response_data.( *string  )
+										sp.Set_phost( phost )
+										rm_sheep.Baa( 1, "passthrou phost found  for chkptd reservation: %s %s %s", *(sp.Get_id()), *host, *phost )
+										err = i.Add_res( p )
+									} else {
+										s := fmt.Errorf( "unknown reason" )
+										if req.State != nil {
+											s = req.State
+										}
+										rm_sheep.Baa( 0, "ERR: resmgr: ckpt_laod: unable to find phost for passthru pledge: %s	[TGURMG000]", s )
+										rm_sheep.Baa( 0, "erroring passthru pledge: %s", (*p).To_str() )
+									}
+									
 
 								default:
 									rm_sheep.Baa( 0, "rmgr/load_ckpt: unrecognised pledge type" )

--- a/managers/res_mgr.go
+++ b/managers/res_mgr.go
@@ -129,7 +129,7 @@ import (
 */
 type Inventory struct {
 	cache		map[string]*gizmos.Pledge		// cache of pledges
-	ulcap_cache	map[string]int					// cache of user limit values (max value)
+	ulcap_cache	map[string]int					// cache of user link capacity values (max value)
 	chkpt		*chkpt.Chkpt
 }
 

--- a/managers/res_mgr_pt.go
+++ b/managers/res_mgr_pt.go
@@ -1,0 +1,112 @@
+// vi: sw=4 ts=4:
+/*
+ ---------------------------------------------------------------------------
+   Copyright (c) 2013-2015 AT&T Intellectual Property
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at:
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ ---------------------------------------------------------------------------
+*/
+
+
+/*
+
+	Mnemonic:	res_mgr_pt
+	Abstract:	Functions which apply only to the passthrough reservations.
+
+	Date:		26 January 2016
+	Author:		E. Scott Daniels
+
+	Mods:		
+*/
+
+package managers
+
+import (
+	"time"
+
+	"github.com/att/gopkgs/ipc"
+	"github.com/att/tegu/gizmos"
+)
+
+/*
+	For a single passthrough pledge, this function sets things up and sends needed requests to the fq-manger to
+	create any necessary flow-mods.
+
+	We send the following information to fq_mgr:
+		source mac or endpoint	(VM-- the host in the pledge)
+		source IP and optionally port and protocol more specific reservations
+		expiry
+		switch	(physical host -- compute node)
+	
+	Errors are returned to res_mgr via channel, but asycnh; we do not wait for responses to each message
+	generated here.
+
+	To_limit is a cap to the expiration time sent when creating a flow-mod.  OVS (and others we assume)
+	use an unsigned int32 as a hard timeout value, and thus have an upper limit of just over 18 hours. If
+	to_limit is > 0, we'll ensure that the timeout passed on the request to fq-mgr won't exceed  the limit,
+ 	and we assume that this function is called periodically to update long running reservations.
+*/
+func pass_push_res( gp *gizmos.Pledge, rname *string, ch chan *ipc.Chmsg, to_limit int64 ) {
+	var (
+		msg		*ipc.Chmsg
+	)
+
+	now := time.Now().Unix()
+
+	p, ok :=  (*gp).( *gizmos.Pledge_pass )		// generic pledge better be a passthrough pledge!
+	if ! ok {
+		rm_sheep.Baa( 1, "internal error in pass_push_reservation: pledge isn't a passthrough pledge" )
+		(*gp).Set_pushed()						// prevent looping
+		return
+	}
+
+	host, _,  _, expiry, proto := p.Get_values( )			// reservation info that we need
+	//v1, v2 := p.Get_vlan( )								// vlan match criteria for one/both endpoints
+
+	ip := name2ip( host )
+rm_sheep.Baa( 1, ">>>>> host name %s converted to ip address for freq", *host, *ip )
+
+	if ip != nil {											// good ip addresses so we're good to go
+		freq := Mk_fqreq( rname )						// default flow mod request with empty match/actions (for bw requests, we don't need priority or such things)
+		freq.Match.Smac = ip							// fq_mgr has conversion map to convert to mac
+		freq.Swid = p.Get_phost()						// the phyiscal host where the VM lives and where fmods need to be deposited
+
+		freq.Cookie = 0xffff							// should be ignored, if we see this out there we've got problems
+
+		if (*p).Is_paused( ) {
+			freq.Expiry = time.Now().Unix( ) +  15		// if reservation shows paused, then we set the expiration to 15s from now  which should force the flow-mods out
+		} else {
+			if to_limit > 0 && expiry > now + to_limit {
+				freq.Expiry = now + to_limit			// expiry must be capped so as not to overflow virtual switch variable size
+			} else {
+				freq.Expiry = expiry
+			}
+		}
+		freq.Id = rname
+
+		freq.Extip = &empty_str
+
+														// this will change when ported to endpoint branch as the endpoint allows address and port 'in line'
+		freq.Match.Ip1 = proto							// the proto on the reservation should be [{udp|tcp:}]address[:port]
+		freq.Match.Ip2 = nil
+		freq.Espq =   nil
+		dup_str := ""
+		freq.Exttyp = &dup_str
+
+		rm_sheep.Baa( 1, "pushing passthru reservation: %s", p )
+		msg = ipc.Mk_chmsg()
+		msg.Send_req( fq_ch, ch, REQ_PT_RESERVE, freq, nil )					// queue work with fq-manger to read the struct and send cmd(s) to agent to get it done
+
+		p.Set_pushed()				// safe to mark the pledge as having been pushed.
+	}
+}

--- a/managers/res_mgr_pt.go
+++ b/managers/res_mgr_pt.go
@@ -71,10 +71,8 @@ func pass_push_res( gp *gizmos.Pledge, rname *string, ch chan *ipc.Chmsg, to_lim
 	}
 
 	host, _,  _, expiry, proto := p.Get_values( )			// reservation info that we need
-	//v1, v2 := p.Get_vlan( )								// vlan match criteria for one/both endpoints
 
 	ip := name2ip( host )
-rm_sheep.Baa( 1, ">>>>> host name %s converted to ip address for freq", *host, *ip )
 
 	if ip != nil {											// good ip addresses so we're good to go
 		freq := Mk_fqreq( rname )						// default flow mod request with empty match/actions (for bw requests, we don't need priority or such things)

--- a/support/tegu_verification.ksh
+++ b/support/tegu_verification.ksh
@@ -27,6 +27,11 @@
 #---------------------------------------------------------------------------------
 
 
+function log_failure
+{
+	echo "$1"
+	echo "$1" >>$out_file
+}
 
 # check the file for a simple ERROR or not. Return good (0)
 # if error not observed.
@@ -64,7 +69,7 @@ function validate_ok
 {
 	if ! isok $1
 	then
-		echo "FAIL: $global_comment"
+		log_failure "FAIL: $global_comment"
 		(( errors++ ))
 		if (( short_circuit ))
 		then
@@ -81,7 +86,7 @@ function validate_fail
 {
 	if isok $1
 	then
-		echo "FAIL: $global_comment"
+		log_failure "FAIL: $global_comment"
 		(( errors++ ))
 		if (( short_circuit ))
 		then
@@ -115,7 +120,7 @@ function validate_contains
 		then
 			echo "OK:   $global_comment"
 		else
-			echo "FAIL: $fmsg, but did not contain expected data: ($2)"
+			log_failure "FAIL: $fmsg, but did not contain expected data: ($2)"
 			echo "	log eye catcher: $global_comment"
 			(( errors++ ))
 			if (( short_circuit ))
@@ -125,7 +130,7 @@ function validate_contains
 			return
 		fi
 	else
-		echo "FAIL: $global_comment"
+		log_failure "FAIL: $global_comment"
 		(( errors++ ))
 		if (( short_circuit ))
 		then
@@ -156,7 +161,7 @@ function validate_missing
 		then
 			echo "OK:   $global_comment"
 		else
-			echo "FAIL: $fmsg, but contained unexpected data: ($2) $global_comment"
+			log_failure "FAIL: $fmsg, but contained unexpected data: ($2) $global_comment"
 			(( errors++ ))
 			if (( short_circuit ))
 			then
@@ -165,7 +170,7 @@ function validate_missing
 			return
 		fi
 	else
-		echo "FAIL: $global_comment"
+		log_failure "FAIL: $global_comment"
 		(( errors++ ))
 		return
 	fi
@@ -324,7 +329,7 @@ for v in $p1vm_list
 do
 	if ! grep -q "${endpts[$v]}" $single_file
 	then
-		echo "FAIL: $v (${endpts[$v]}) not found in list host output for project $project1"
+		log_failure "FAIL: $v (${endpts[$v]}) not found in list host output for project $project1"
 		(( count++ ))
 	fi
 done
@@ -433,12 +438,12 @@ validate_contains $single_file 'comment = user link cap set for.*1[%]*$'
 # ----- verify link cap is enforced (assuming 10G links, with 1% cap, a request for 500M should fail) ---------------------
 #trace="set -x"
 run tegu_req -c -T $secure $host reserve 500M +90 %t/$project1/${p1vm_list[0]},%t/$project1/${p1vm_list[1]} cookie voice >$single_file
-capture $single_file "reservation rejected when exceeds user cap"
+capture $single_file "reservation rejected when exceeds user cap (failure in relaxed mode is OK)"
 validate_contains -f $single_file "unable to generate a path"
 trace="set +x"
 
 run tegu_req -c -T $secure $host reserve 5M +90 %t/$project1/${p1vm_list[0]},%t/$project1/${p1vm_list[1]} cookie voice >$single_file
-capture $single_file "reservation accepted when less than link cap"
+capture $single_file "reservation accepted when less than link cap (failure in relaxed mode is OK)"
 validate_ok $single_file
 
 # ---- set zero link cap ----------------------------------------------------
@@ -473,7 +478,7 @@ then
 	run tegu_req -c $secure $host listres | grep -c $rid |read count
 	if (( count ))
 	then
-		echo "FAIL: still found oneway reservation in list after cancel"
+		log_failure "FAIL: still found oneway reservation in list after cancel"
 	else
 		echo "OK:   oneway reservation cancel successfully removed the resrvation from the list"
 	fi
@@ -484,7 +489,7 @@ fi
 
 # ======== PASSTHRU TESTING =========================================================================================
 run tegu_req -c -T $secure $host passthru +90 %t/%p/${p1vm_list[0]} ptcookie >$single_file
-capture $single_file "passthru reservation can be created"
+capture $single_file "passthru reservation can be created (failure if relaxed=false is expected)"
 validate_ok $single_file
 
 suss_rid $single_file | read rid
@@ -499,7 +504,7 @@ then
 	run tegu_req -c $secure $host listres | grep -c $rid |read count
 	if (( count ))
 	then
-		echo "FAIL: still found passthru reservation in list after cancel"
+		log_failure "FAIL: still found passthru reservation in list after cancel"
 		capture $single_file "reservation list active when passthru check failed (res=$rid)"
 	else
 		echo "OK:   passthru reservation cancel successfully removed the resrvation from the list"
@@ -514,13 +519,13 @@ capture $single_file "set ulcap to 0 to ensure it blocks passthru"
 validate_contains $single_file 'comment = user link cap set for.*0[%]*$'
 
 run tegu_req -c -T $secure $host passthru +90 %t/%p/${p1vm_list[0]} ptcookie >$single_file
-capture $single_file "passthru reservation can is rejected if ulcap is 0"
+capture $single_file "passthru reservation is rejected if ulcap is 0"
 validate_fail $single_file
 
 
 # ---- return link cap to sane value ----------------------------------------------------
 run tegu_req -c $secure $host setulcap $project1 90 >$single_file
-capture $single_file "user link cap can be set back up (90%)"
+capture $single_file "reset ulcap back up after passthru reject test (cap=90%)"
 validate_ok $single_file
 
 
@@ -553,7 +558,7 @@ capture $single_file "canceling all with non-matching cookie leave non-matching 
 grep -c time $single_file.more | read count
 if (( count <= 0 ))
 then
-	echo "FAIL:	cancel all reservations with cookie leave non-matching reservations"
+	log_failure "FAIL:	cancel all reservations with cookie leave non-matching reservations"
 else
 	echo "OK:   cancel all left non-matching reservations"
 fi
@@ -565,8 +570,9 @@ tegu_req -c $host $secure listres >$single_file
 grep  "time =" $single_file| awk '($NF)+0 > 15 { count++ } END { print count+0 }' | read count
 if (( count > 0 ))
 then
-	echo "FAIL:	reservations with cookie remain"
-	capture $single_file "cookie reservations remained (expected all to be deleted)"
+	log_failure "FAIL:	reservations with cookie remain"
+	echo "NOTE:  this can happen if reservations that _should_ have been deleted earlier still exist" >>$out_file
+	capture $single_file "$count cookie reservations remained with time >15s  (reservation dump below)"
 	grep  "time =" $single_file| grep  -v "time.*=.*15"
 else
 	echo "OK:   delete of all reservations with the same cookie"

--- a/system/tegu_req.ksh
+++ b/system/tegu_req.ksh
@@ -74,6 +74,7 @@
 #					verification quicker.
 #				24 Nov 2015 - Add options to add-mirror
 #				16 Dec 2015 - Correct OS_REGION env reference to be correct (OS_REGION_NAME)
+#				27 Jan 2016 - Added support for passthru
 # ----------------------------------------------------------------------------------------
 
 function usage {
@@ -113,6 +114,7 @@ function usage {
 	commands and parms are one of the following:
 	  $argv0 reserve [bandwidth_in,]bandwidth_out [start-]expiry token/project/host1,token/project/host2 cookie [dscp]
 	  $argv0 owreserve bandwidth_out [start-]expiry token/project/host1,token/project/host2 cookie [dscp]
+	  $argv0 passtrhu  [start-]expiry token/project/host cookie
 	  $argv0 cancel reservation-id [cookie]
 	  $argv0 listconns {name[ name]... | <file}
 	  $argv0 add-mirror [start-]end port1[,port2...] output [cookie] [vlan]
@@ -623,6 +625,21 @@ case $1 in
 		esac
 
 		rjprt $opts -m DELETE -D "reservation $1 $2" -t "$proto$host/$bandwidth"
+		;;
+
+	passthru|passthrough)
+		shift
+		# tegu wants passthru [proto=[{udp|tcp}:]address[:port]] timewindow|+sss token/proj/vm cookie
+		if [[ $# < 3 ]] 
+		then
+			echo "found $# positional parameters on the command line, expected three.i   [FAIL]"
+			echo "missing positional parameters: [<start]-]end|+sss token/project/VM cookie"
+			echo " "
+			usage
+			exit 1
+		fi
+		expiry=$( str2expiry $1 )
+		rjprt  $opts -m POST -D "passthru $kv_pairs $expiry $(expand_epname "$raw_token" "$OS_TENANT_NAME" $2) $3" -t "$proto$host/$bandwidth"
 		;;
 
 	pause)


### PR DESCRIPTION
Passthru reservations allow DSCP markings to pass through the ingress switch unchanged (avoiding being marked down to 0 by the Tegu priority 10 flow-mod which enforces the policy that only reservation traffic may be marked with DSCP values.   The reservation is  allowed only if the user link capacity for the project owning the endpoint (VM) is greater than 0, and if relaxed mode is turned on the  config file (bandwidth pathing is not being done). 
